### PR TITLE
Add chapi resources.

### DIFF
--- a/plugfest-2-2022/index.md
+++ b/plugfest-2-2022/index.md
@@ -128,13 +128,15 @@ $10,000 will be available to each organization (wallet/issuer/both) that demonst
 * [DID Actor](https://api.did.actor/)
 * [DIDComm](https://didcomm.org/)
 * [DID DIF Universal Resolver](https://dev.uniresolver.io/)
-* [Hosted platform to resolve and manage DIDs](https://godiddy.com/[VC-API](https://github.com/w3c-ccg/vc-api/)
+* [Hosted platform to resolve and manage DIDs](https://godiddy.com/[VC-API](https://github.com/w3c-ccg/vc-api/)+
+* [CHAPI - Credential Handler API](https://chapi.io)
 * [OIDC- OpenID for VCs] (https://openid.net/wordpress-content/uploads/2022/05/OIDF-Whitepaper_OpenID-for-Verifiable-Credentials_FINAL_2022-05-12.pdf)
 * [Open Badges 3.0](https://imsglobal.github.io/openbadges-specification/ob_v3p0.html)
 * [Plugfest 1](https://w3c-ccg.github.io/vc-ed/plugfest-1-2022/)
 * [Plugfest 1 Participants](https://w3c-ccg.github.io/vc-ed/plugfest-1-2022/participants.html)
 * Protocols:
   * [Verifiable Credentials HTTP API v0.3 - VC-API](https://w3c-ccg.github.io/vc-api/)
+  * CHAPI Quick Reference: [for Issuers](https://chapi.io/developers/issuers), [for Digital Wallets](https://chapi.io/developers/wallets), [for Verifiers](https://chapi.io/developers/verifiers)
   * [OpenID for Verifiable Credential Issuance](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html)
   * [WACI-DIDComm Interop Profile](https://identity.foundation/waci-didcomm/)
 * [Universal Wallet](https://w3c-ccg.github.io/universal-wallet-interop-spec/)

--- a/plugfest-2-2022/index.md
+++ b/plugfest-2-2022/index.md
@@ -128,9 +128,10 @@ $10,000 will be available to each organization (wallet/issuer/both) that demonst
 * [DID Actor](https://api.did.actor/)
 * [DIDComm](https://didcomm.org/)
 * [DID DIF Universal Resolver](https://dev.uniresolver.io/)
-* [Hosted platform to resolve and manage DIDs](https://godiddy.com/[VC-API](https://github.com/w3c-ccg/vc-api/)+
+* [Hosted platform to resolve and manage DIDs](https://godiddy.com/)
+* [VC-API](https://github.com/w3c-ccg/vc-api/)
 * [CHAPI - Credential Handler API](https://chapi.io)
-* [OIDC- OpenID for VCs] (https://openid.net/wordpress-content/uploads/2022/05/OIDF-Whitepaper_OpenID-for-Verifiable-Credentials_FINAL_2022-05-12.pdf)
+* [OIDC- OpenID for VCs](https://openid.net/wordpress-content/uploads/2022/05/OIDF-Whitepaper_OpenID-for-Verifiable-Credentials_FINAL_2022-05-12.pdf)
 * [Open Badges 3.0](https://imsglobal.github.io/openbadges-specification/ob_v3p0.html)
 * [Plugfest 1](https://w3c-ccg.github.io/vc-ed/plugfest-1-2022/)
 * [Plugfest 1 Participants](https://w3c-ccg.github.io/vc-ed/plugfest-1-2022/participants.html)


### PR DESCRIPTION
Adds a few links to the Resources section of the PlugFest2 Page - overview and developer docs for the Credential Handler API (CHAPI)